### PR TITLE
feat: correct ticker name to conform to the specification

### DIFF
--- a/bip.mediawiki
+++ b/bip.mediawiki
@@ -176,7 +176,7 @@ It's a example of deploy script as following:
 { 
   "p": "drc-20",
   "op": "deploy",
-  "tick": "dogewow",
+  "tick": "dgww",
   "max": "1000000",
   "lim": "100"
 }
@@ -213,7 +213,7 @@ It's a example of mint script as following:
 { 
   "p": "drc-20",
   "op": "mint",
-  "tick": "dogewow",
+  "tick": "dgww",
   "amt": "100"
 }
 </pre>
@@ -241,7 +241,7 @@ It's a example of transfer script as following:
 { 
   "p": "drc-20",
   "op": "transfer",
-  "tick": "dogewow",
+  "tick": "dgww",
   "amt": "230"
 }
 </pre>


### PR DESCRIPTION
- Change 'dogewow' ticker to 'dgww', in order to conform to the 3-4 character ticker limit

Closes #1